### PR TITLE
Remove namespace from the policy-agent templates

### DIFF
--- a/charts/weave-policy-agent/Chart.yaml
+++ b/charts/weave-policy-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Weaveworks Helm chart for Kubernetes to configure the policy agent
 name: weave-policy-agent
 appVersion: "1.0"
-version: 0.3.0
+version: 0.3.1
 kubeVersion: ">=1.16.0-0"
 icon: https://www.magalix.com/hubfs/Imported%20images/logo-02.png%3Fwidth=560%26name=logo-02-Dec-18-2020-11-24-41-75-AM.png
 type: application
@@ -12,7 +12,7 @@ sources:
   - https://github.com/weaveworks/policy-agent
 
 keywords:
-- policy
+  - policy
 
 maintainers:
   - name: Weaveworks

--- a/charts/weave-policy-agent/templates/agent.yaml
+++ b/charts/weave-policy-agent/templates/agent.yaml
@@ -1,15 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    agent-admission: ignore
-    app.kubernetes.io/name: "{{ .Values.namespace }}"
-    app.kubernetes.io/version: "1"
-    app.kubernetes.io/component: "namespace"
-    app.kubernetes.io/tier: "backend"
-  name: {{ .Values.namespace }}
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: policy-agent
@@ -260,3 +249,6 @@ webhooks:
       - key: agent-admission
         operator: NotIn
         values: ["ignore"]
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values: [{{ .Release.Namespace }}]


### PR DESCRIPTION
- This can be created with `helm install --create-namespace` or with
  `install.createNamespace: true` in a HelmRelease file
- We've changed the default behaviour when creating HelmReleases on new
  clusters so that we always create the release namespace. The policy
  chart here no longer installs as the namespace already exists.
- It seems to be a more common pattern that not to omit the namespace
  from templates and allow the helm tooling to take care of it (e.g.
  cert-manager)