### PR TITLE
Adding the metallb profile for using with bare metal clusters

### DIFF
--- a/charts/metallb/.helmignore
+++ b/charts/metallb/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/metallb/Chart.lock
+++ b/charts/metallb/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: metallb
+  repository: https://metallb.github.io/metallb
+  version: 0.13.3
+digest: sha256:f5075b9011e5b03dc7dc029a0ce2c2094cc85825d8f1ab0c5274db092d2a8e96
+generated: "2022-07-11T17:36:17.965016099+01:00"

--- a/charts/metallb/Chart.yaml
+++ b/charts/metallb/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: metallb
+icon: https://metallb.universe.tf/images/logo/metallb-white.png
+description: A Weaveworks Helm chart for a network load-balancer implementation for Kubernetes using standard routing protocols
+type: application
+version: 0.0.1
+dependencies:
+  - name: metallb
+    version: "v0.13.3"
+    repository: "https://metallb.github.io/metallb"
+kubeVersion: ">=1.16.0-0"
+home: https://github.com/weaveworks/profiles-catalog
+sources:
+  - https://metallb.github.io/metallb
+
+keywords:
+- metallb
+- loadbalancer
+- kind
+
+maintainers:
+  - name: Weaveworks
+    email: support@weave.works
+
+annotations:
+  "weave.works/profile": metallb
+  "weave.works/category": Loadbalancer
+  "weave.works/layer": layer-0
+  "weave.works/operator": "false"
+  "weave.works/links": |
+    - name: Chart Sources
+      url: https://metallb.github.io/metallb
+    - name: Upstream Project
+      url: https://github.com/metallb/metallb
+  "weave.works/profile-ci": |
+    - "kind"

--- a/charts/metallb/templates/NOTES.txt
+++ b/charts/metallb/templates/NOTES.txt
@@ -1,0 +1,3 @@
+Thank you for installing {{ .Chart.Name }} {{ .Chart.Version }} 😀
+
+Your release is named {{ .Release.Name }}, app version {{ .Chart.AppVersion }}

--- a/charts/metallb/templates/_helpers.tpl
+++ b/charts/metallb/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metallb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "metallb.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "metallb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "metallb.labels" -}}
+helm.sh/chart: {{ include "metallb.chart" . }}
+{{ include "metallb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "metallb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "metallb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "metallb.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "metallb.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -10,9 +10,9 @@ configInline:
     - name: default
       protocol: layer2
       # replace the address with a subnet address range for your environment
-      # by adding 100 to the control plane IP.
+      # by adding 200 to the control plane IP.
       # For example for demo2, LM30 would be:
       # control plane: 172.16.20.30/32
-      # MetalLB address: 172.16.20.130/32
+      # MetalLB address: 172.16.20.230/32
       addresses:
-      - 172.16.20.151/32
+      - 172.16.20.251/32

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -1,0 +1,18 @@
+prometheus:
+  # Set the prometheus namespace if podMonitor is enabled
+  namespace: ""
+  podMonitor:
+    enabled: false
+  prometheusRule:
+    enabled: false
+configInline:
+  address-pools:
+    - name: default
+      protocol: layer2
+      # replace the address with a subnet address range for your environment
+      # by adding 100 to the control plane IP.
+      # For example for demo2, LM30 would be:
+      # control plane: 172.16.20.30/32
+      # MetalLB address: 172.16.20.130/32
+      addresses:
+      - 172.16.20.151/32


### PR DESCRIPTION
Adding the initial version of the metallb profile for use with bare metal clusters.
This is needed for bare metal cluster demonstrations to allow workload access to the cluster.

The profile includes the address subnet to use for the cluster and should be tuned for each cluster.