### PR TITLE
add an ingress-nginx profile for use on workload clusters

### DIFF
--- a/charts/ingress-nginx/.helmignore
+++ b/charts/ingress-nginx/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ingress-nginx/Chart.lock
+++ b/charts/ingress-nginx/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.1.0
+digest: sha256:8b7073d6a936bbabe553db735ea45d0f50517dcbaafd96f1cbb6b97f1e93023d
+generated: "2022-04-23T00:02:38.992093991Z"

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,0 +1,37 @@
+apiVersion: v2
+name: ingress-nginx
+icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
+description: A Weaveworks Helm chart for ingress-nginx
+type: application
+version: 0.0.11
+kubeVersion: ">=1.16.0-0"
+home: https://github.com/weaveworks/profiles-catalog
+sources:
+  - https://kubernetes.github.io/ingress-nginx
+
+keywords:
+- network
+- ingress
+- nginx
+- nginx-ingress
+
+maintainers:
+  - name: Weaveworks
+    email: support@weave.works
+
+annotations:
+  "weave.works/profile": ingress-nginx
+  "weave.works/category": Ingress
+  "weave.works/layer": layer-1
+  "weave.works/links": |
+    - name: Chart Sources
+      url:  https://kubernetes.github.io/ingress-nginx
+    - name: Upstream Project
+      url: https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx
+  "weave.works/profile-ci": |
+    - "gke"
+
+dependencies:
+- name: ingress-nginx
+  version: "4.1.0"
+  repository: "https://kubernetes.github.io/ingress-nginx"

--- a/charts/ingress-nginx/templates/NOTES.txt
+++ b/charts/ingress-nginx/templates/NOTES.txt
@@ -1,0 +1,1 @@
+The ingress-nginx controller has been installed.

--- a/charts/ingress-nginx/templates/_helpers.tpl
+++ b/charts/ingress-nginx/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ingress-nginx.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ingress-nginx.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ingress-nginx.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ingress-nginx.labels" -}}
+helm.sh/chart: {{ include "ingress-nginx.chart" . }}
+{{ include "ingress-nginx.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ingress-nginx.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ingress-nginx.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ingress-nginx.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ingress-nginx.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -1,0 +1,8 @@
+ingress-nginx:
+  controller:
+    service:
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+        networking.gke.io/load-balancer-type: "Internal"
+        service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+        service.beta.kubernetes.io/oci-load-balancer-internal: "true"


### PR DESCRIPTION
This adds the ingress-nginx profile for use when deploying workload clusters so we can define ingress objects to reach workload cluster services.