### PR TITLE
changing order in chart to trigger releaser action

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -9,6 +9,11 @@ home: https://github.com/weaveworks/profiles-catalog
 sources:
   - https://kubernetes.github.io/ingress-nginx
 
+dependencies:
+- name: ingress-nginx
+  version: "4.1.0"
+  repository: "https://kubernetes.github.io/ingress-nginx"
+
 keywords:
 - network
 - ingress
@@ -31,7 +36,3 @@ annotations:
   "weave.works/profile-ci": |
     - "gke"
 
-dependencies:
-- name: ingress-nginx
-  version: "4.1.0"
-  repository: "https://kubernetes.github.io/ingress-nginx"


### PR DESCRIPTION
This is needed to fix issue: https://github.com/weaveworks/weave-gitops-profile-examples/issues/50

In order to trigger the release of the ingress-nginx chart I have made an inconsequential change to the chart.
This will re-trigger the chart releaser action.