### PR TITLE
Fix elk stack values for template engine

### DIFF
--- a/charts/elk-stack/Chart.yaml
+++ b/charts/elk-stack/Chart.yaml
@@ -3,7 +3,7 @@ name: elk-stack
 icon: https://static-www.elastic.co/v3/assets/bltefdd0b53724fa2ce/blt74acb493aaf69084/5ea8c8dbf5880355558334cd/brand-elastic-stack-220x130.svg
 description: A Weaveworks Helm chart for the ELK Stack Profile
 type: application
-version: 0.0.7
+version: 0.0.8
 dependencies:
 - name: elasticsearch
   version: "7.17.3"

--- a/charts/elk-stack/values.yaml
+++ b/charts/elk-stack/values.yaml
@@ -77,10 +77,10 @@ elasticsearch:
       #!/usr/bin/env bash
       set -euo pipefail
       elasticsearch-certutil cert \
-        --name ${NODE_NAME} \
+        --name $${NODE_NAME} \
         --days 1000 \
-        --ip ${POD_IP} \
-        --dns ${NODE_NAME},${POD_SERVICE_NAME},${POD_SERVICE_NAME_HEADLESS},${NODE_NAME}.${POD_SERVICE_NAME},${NODE_NAME}.${POD_SERVICE_NAME_HEADLESS} \
+        --ip $${POD_IP} \
+        --dns $${NODE_NAME},$${POD_SERVICE_NAME},$${POD_SERVICE_NAME_HEADLESS},$${NODE_NAME}.$${POD_SERVICE_NAME},$${NODE_NAME}.$${POD_SERVICE_NAME_HEADLESS} \
         --ca-cert /usr/share/elasticsearch/config/certs/tls.crt \
         --ca-key /usr/share/elasticsearch/config/certs/tls.key  \
         --ca-pass "" \


### PR DESCRIPTION
The elk-stack profile did not work as the variables in the extraInitContainers field of the values.yaml contains varaiables like: 
${NODE_NAME}
The profiles template engine tries to replace these values, but they do not exist.
They are designed to be replaced by ENV varaibles when the pod runs.

In order to try and avoid this issue we have added a $ to each var, so it now looks like this:
$${NODE_NAME}

Testing this to see if it works.