### PR TITLE
upgrade the rest of elk stack to version 7.17.3, release profile 0.0.9

### DIFF
--- a/charts/elk-stack/Chart.lock
+++ b/charts/elk-stack/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 7.17.3
 - name: kibana
   repository: https://helm.elastic.co
-  version: 7.16.3
+  version: 7.17.3
 - name: metricbeat
   repository: https://helm.elastic.co
-  version: 7.16.3
+  version: 7.17.3
 - name: filebeat
   repository: https://helm.elastic.co
   version: 7.17.3
-digest: sha256:6fb0ed5a0aecd9b3a6bd153caefa4c6b38d664cb909e88c81dd9975d2365000d
-generated: "2022-05-11T12:37:39.942264-04:00"
+digest: sha256:3ae9d28404180e0920cd7f6c84f6401348f55b9c64dbd23c9b491a34747cccb2
+generated: "2022-09-01T18:08:56.696158059+01:00"

--- a/charts/elk-stack/Chart.yaml
+++ b/charts/elk-stack/Chart.yaml
@@ -3,16 +3,16 @@ name: elk-stack
 icon: https://static-www.elastic.co/v3/assets/bltefdd0b53724fa2ce/blt74acb493aaf69084/5ea8c8dbf5880355558334cd/brand-elastic-stack-220x130.svg
 description: A Weaveworks Helm chart for the ELK Stack Profile
 type: application
-version: 0.0.8
+version: 0.0.9
 dependencies:
 - name: elasticsearch
   version: "7.17.3"
   repository: "https://helm.elastic.co"
 - name: kibana
-  version: "7.16.3"
+  version: "7.17.3"
   repository: "https://helm.elastic.co"
 - name: metricbeat
-  version: "7.16.3"
+  version: "7.17.3"
   repository: "https://helm.elastic.co"
 - name: filebeat
   version: "7.17.3"


### PR DESCRIPTION
The elk-stack version had been partially updated so some of the stack was version 7.17.3 and some was on 7.16.3 and this caused some errors with the latest K8s version.
The profile is now a consistent version of 7.17.3 across all dependencies.
The profile version was incremented to 0.0.9.