### PR TITLE
universal crossplane

### DIFF
--- a/capi/templates/universal-crossplane-template.yaml
+++ b/capi/templates/universal-crossplane-template.yaml
@@ -1,0 +1,164 @@
+apiVersion: capi.weave.works/v1alpha1
+kind: CAPITemplate
+metadata:
+  name: crossplane
+  namespace: default
+  annotations:
+    templates.weave.works/profiles-enabled: 'true'
+    templates.weave.works/kustomizations-enabled: 'true'
+    templates.weave.works/credentials-enabled: 'true'
+    capi.weave.works/profile-0: '{"name": "cert-manager","version": "0.0.9","namespace": "cert-system"}'
+    capi.weave.works/profile-1: '{"name": "weave-policy-agent", "editable": true, "version": "0.5.4", "namespace": "policy-system", "values": "policy-agent:\n  config:\n    AGENT_ENABLE_ADMISSION: \"1\"\n    accountId: tony\n    clusterId: ${CLUSTER_NAME}" }'
+    capi.weave.works/profile-2: '{"name": "universal-crossplane-policies", "version": "0.0.1"}'
+    capi.weave.works/profile-3: '{"name": "universal-crossplane", "version": "0.0.1", "namespace": "crossplane"}'
+spec:
+  description: A simple CAPD template that will install logging tools with your leaf cluster
+  params:
+    - name: CLUSTER_NAME
+      required: true
+      description: This is used for the cluster naming.
+    - name: NAMESPACE
+      description: Namespace to create the cluster in
+    - name: KUBERNETES_VERSION
+      description: Kubernetes version to use for the cluster
+      options: ["1.19.11", "1.21.1", "1.22.0", "1.23.3"]
+    - name: CONTROL_PLANE_MACHINE_COUNT
+      description: Number of control planes
+      options: ["1", "2", "3"]
+    - name: WORKER_MACHINE_COUNT
+      description: Number of control planes
+  resourcetemplates:
+    - apiVersion: gitops.weave.works/v1alpha1
+      kind: GitopsCluster
+      metadata:
+        name: "${CLUSTER_NAME}"
+        namespace: "${NAMESPACE}"
+        labels:
+          weave.works/capi: bootstrap
+      spec:
+        capiClusterRef:
+          name: "${CLUSTER_NAME}"
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      kind: Cluster
+      metadata:
+        name: "${CLUSTER_NAME}"
+        namespace: "${NAMESPACE}"
+        labels:
+          cni: calico
+      spec:
+        clusterNetwork:
+          pods:
+            cidrBlocks:
+              - 192.168.0.0/16
+          serviceDomain: cluster.local
+          services:
+            cidrBlocks:
+              - 10.128.0.0/12
+        controlPlaneRef:
+          apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+          kind: KubeadmControlPlane
+          name: "${CLUSTER_NAME}-control-plane"
+          namespace: "${NAMESPACE}"
+        infrastructureRef:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: DockerCluster
+          name: "${CLUSTER_NAME}"
+          namespace: "${NAMESPACE}"
+    - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerCluster
+      metadata:
+        name: "${CLUSTER_NAME}"
+        namespace: "${NAMESPACE}"
+    - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerMachineTemplate
+      metadata:
+        name: "${CLUSTER_NAME}-control-plane"
+        namespace: "${NAMESPACE}"
+      spec:
+        template:
+          spec:
+            extraMounts:
+              - containerPath: /var/run/docker.sock
+                hostPath: /var/run/docker.sock
+    - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlane
+      metadata:
+        name: "${CLUSTER_NAME}-control-plane"
+        namespace: "${NAMESPACE}"
+      spec:
+        kubeadmConfigSpec:
+          clusterConfiguration:
+            apiServer:
+              certSANs:
+                - localhost
+                - 127.0.0.1
+                - 0.0.0.0
+            controllerManager:
+              extraArgs:
+                enable-hostpath-provisioner: "true"
+          initConfiguration:
+            nodeRegistration:
+              criSocket: /var/run/containerd/containerd.sock
+              kubeletExtraArgs:
+                cgroup-driver: cgroupfs
+                eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          joinConfiguration:
+            nodeRegistration:
+              criSocket: /var/run/containerd/containerd.sock
+              kubeletExtraArgs:
+                cgroup-driver: cgroupfs
+                eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        machineTemplate:
+          infrastructureRef:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: DockerMachineTemplate
+            name: "${CLUSTER_NAME}-control-plane"
+            namespace: "${NAMESPACE}"
+        replicas: "${CONTROL_PLANE_MACHINE_COUNT}"
+        version: "${KUBERNETES_VERSION}"
+    - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerMachineTemplate
+      metadata:
+        name: "${CLUSTER_NAME}-md-0"
+        namespace: "${NAMESPACE}"
+      spec:
+        template:
+          spec: {}
+    - apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+      kind: KubeadmConfigTemplate
+      metadata:
+        name: "${CLUSTER_NAME}-md-0"
+        namespace: "${NAMESPACE}"
+      spec:
+        template:
+          spec:
+            joinConfiguration:
+              nodeRegistration:
+                kubeletExtraArgs:
+                  cgroup-driver: cgroupfs
+                  eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      kind: MachineDeployment
+      metadata:
+        name: "${CLUSTER_NAME}-md-0"
+        namespace: "${NAMESPACE}"
+      spec:
+        clusterName: "${CLUSTER_NAME}"
+        replicas: "${WORKER_MACHINE_COUNT}"
+        selector:
+          matchLabels: null
+        template:
+          spec:
+            bootstrap:
+              configRef:
+                apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+                kind: KubeadmConfigTemplate
+                name: "${CLUSTER_NAME}-md-0"
+                namespace: "${NAMESPACE}"
+            clusterName: "${CLUSTER_NAME}"
+            infrastructureRef:
+              apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+              kind: DockerMachineTemplate
+              name: "${CLUSTER_NAME}-md-0"
+              namespace: "${NAMESPACE}"
+            version: "${KUBERNETES_VERSION}"

--- a/capi/templates/universal-crossplane-template.yaml
+++ b/capi/templates/universal-crossplane-template.yaml
@@ -12,153 +12,187 @@ metadata:
     capi.weave.works/profile-2: '{"name": "universal-crossplane-policies", "version": "0.0.1"}'
     capi.weave.works/profile-3: '{"name": "universal-crossplane", "version": "0.0.1", "namespace": "crossplane"}'
 spec:
-  description: A simple CAPD template that will install logging tools with your leaf cluster
+  description: REPLACE HOST IPS (W.X.Y.Z) -Equinix Bare Metal based virtual K8s cluster service.
   params:
     - name: CLUSTER_NAME
-      required: true
-      description: This is used for the cluster naming.
-    - name: NAMESPACE
-      description: Namespace to create the cluster in
+      description: The name for this cluster.
     - name: KUBERNETES_VERSION
-      description: Kubernetes version to use for the cluster
-      options: ["1.19.11", "1.21.1", "1.22.0", "1.23.3"]
-    - name: CONTROL_PLANE_MACHINE_COUNT
-      description: Number of control planes
-      options: ["1", "2", "3"]
+      description: Kubernetes version to use
+      options: ['1.21.8','1.22.8','1.23.5']
+    - name: CONTROL_PLANE__MACHINE_COUNT
+      description: Number of Control Plane nodes to create.
+      options: ['1','3']
+    - name: CONTAINER_NETWORKING 
+      description: Select the CNI plugin to use
+      options: ['cilium']
     - name: WORKER_MACHINE_COUNT
-      description: Number of control planes
+      description: Number of worker nodes to create.
+    - name: CONTROL_PLANE_VIP
+      description: IP for the Kubernetes Endpoint between 172.16.20.1 and 172.16.20.50
   resourcetemplates:
-    - apiVersion: gitops.weave.works/v1alpha1
-      kind: GitopsCluster
-      metadata:
-        name: "${CLUSTER_NAME}"
-        namespace: "${NAMESPACE}"
-        labels:
-          weave.works/capi: bootstrap
-      spec:
-        capiClusterRef:
-          name: "${CLUSTER_NAME}"
-    - apiVersion: cluster.x-k8s.io/v1beta1
-      kind: Cluster
-      metadata:
-        name: "${CLUSTER_NAME}"
-        namespace: "${NAMESPACE}"
-        labels:
-          cni: calico
-      spec:
-        clusterNetwork:
-          pods:
-            cidrBlocks:
-              - 192.168.0.0/16
-          serviceDomain: cluster.local
-          services:
-            cidrBlocks:
-              - 10.128.0.0/12
-        controlPlaneRef:
-          apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-          kind: KubeadmControlPlane
-          name: "${CLUSTER_NAME}-control-plane"
-          namespace: "${NAMESPACE}"
+
+
+  - apiVersion: cluster.x-k8s.io/v1beta1
+    kind: Cluster
+    metadata:
+      labels:
+        cni: ${CONTAINER_NETWORKING}
+      name: ${CLUSTER_NAME}
+      namespace: default
+    spec:
+      clusterNetwork:
+        pods:
+          cidrBlocks:
+          - 172.25.0.0/16
+        services:
+          cidrBlocks:
+          - 172.26.0.0/16
+      controlPlaneRef:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlane
+        name: ${CLUSTER_NAME}-control-plane
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+        kind: MicrovmCluster
+        name: ${CLUSTER_NAME}
+    
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: MicrovmCluster
+    metadata:
+      name: ${CLUSTER_NAME}
+      namespace: default
+    spec:
+      sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDDsOgtZ7ZY/p04GtWLHHFyri5N07/UNawkGl0Z6AX4Q0xO6t8Zx5mh3N5H5qCLwF98GCUmtOTUUwWxM8LHRJ7TrHP3uqQ7I+ZJ/hmp2qkUmsmgWE/3Ng/LyesixqdLXvPW0uhlbD97miLE89G3ZhXGFocbWbPAm2duhqhQ4z/vNuGRcuSNHjGO/a/7eFiXcJ8eP1goHwwTgg+EUZJwjhFTqyVwuNkOG6HhhLeyToKh6wXfsJGopWa7OBBm061xBq9Ct/Ayp5h42YJvYHuYQPvmMFg9dS/jodz1PTFPDlPb0IRpy7iBZKncFfS0BFz3I+EcsHKw83RxBevDrPHkdiH1LjJyyk+lzkeO1JHu+NkQUqu4RkqVjz9FDByu7wk6pYgXvpqzRBuSfDQU0FGQNFU/8QiFlFchVyC09yioDG4xkBQfwYj0DEgwJTRu4w7FEsTplwtnTYTRlvUD1IkX6fmopdAtaHVnrO4hIH8KTLLkx5ZfIK9UKSKlDNFlfGSm3QU= lutz@dellbook"      
+      controlPlaneEndpoint:
+        host: ${CONTROL_PLANE_VIP}
+        port: 6443
+      placement:
+        staticPool:
+          hosts:
+          - controlplaneAllowed: true
+            endpoint: W.X.Y.Z1:9090
+          - controlplaneAllowed: true
+            endpoint: W.X.Y.Z2:9090
+    
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    metadata:
+      name: ${CLUSTER_NAME}-control-plane
+      namespace: default
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration: {}
+        initConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              provider-id: microvm://{{ ds.meta_data.instance_id }}
+        joinConfiguration:
+          nodeRegistration:
+            ignorePreflightErrors:
+            - DirAvailable--etc-kubernetes-manifests
+            kubeletExtraArgs:
+              provider-id: microvm://{{ ds.meta_data.instance_id }}  
+        preKubeadmCommands:
+        - mkdir -p /etc/kubernetes/manifests && ctr images pull ghcr.io/kube-vip/kube-vip:v0.4.0
+          && ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:v0.4.0 vip /kube-vip manifest
+          pod --arp --interface $(ip -4 -j route list default | jq -r .[0].dev) --address
+          ${CONTROL_PLANE_VIP} --controlplane --leaderElection > /etc/kubernetes/manifests/kube-vip.yaml
+      machineTemplate:
         infrastructureRef:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-          kind: DockerCluster
-          name: "${CLUSTER_NAME}"
-          namespace: "${NAMESPACE}"
-    - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: DockerCluster
-      metadata:
-        name: "${CLUSTER_NAME}"
-        namespace: "${NAMESPACE}"
-    - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: DockerMachineTemplate
-      metadata:
-        name: "${CLUSTER_NAME}-control-plane"
-        namespace: "${NAMESPACE}"
-      spec:
-        template:
-          spec:
-            extraMounts:
-              - containerPath: /var/run/docker.sock
-                hostPath: /var/run/docker.sock
-    - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-      kind: KubeadmControlPlane
-      metadata:
-        name: "${CLUSTER_NAME}-control-plane"
-        namespace: "${NAMESPACE}"
-      spec:
-        kubeadmConfigSpec:
-          clusterConfiguration:
-            apiServer:
-              certSANs:
-                - localhost
-                - 127.0.0.1
-                - 0.0.0.0
-            controllerManager:
-              extraArgs:
-                enable-hostpath-provisioner: "true"
-          initConfiguration:
-            nodeRegistration:
-              criSocket: /var/run/containerd/containerd.sock
-              kubeletExtraArgs:
-                cgroup-driver: cgroupfs
-                eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+          kind: MicrovmMachineTemplate
+          name: ${CLUSTER_NAME}-control-plane
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+      version: v${KUBERNETES_VERSION}
+    
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: MicrovmMachineTemplate
+    metadata:
+      name: ${CLUSTER_NAME}-control-plane
+      namespace: default
+    spec:
+      template:
+        spec:
+          kernel:
+            filename: boot/vmlinux
+            image: ghcr.io/weaveworks-liquidmetal/flintlock-kernel:5.10.77
+          kernelCmdline: {}
+          memoryMb: 2048
+          networkInterfaces:
+          - guestDeviceName: eth1
+            type: macvtap
+          rootVolume:
+            id: root
+            image: ghcr.io/weaveworks-liquidmetal/capmvm-kubernetes:${KUBERNETES_VERSION}
+            mountPoint: /
+          vcpu: 2
+    
+  - apiVersion: cluster.x-k8s.io/v1beta1
+    kind: MachineDeployment
+    metadata:
+      name: ${CLUSTER_NAME}-md-0
+      namespace: default
+    spec:
+      clusterName: ${CLUSTER_NAME}
+      replicas: ${WORKER_MACHINE_COUNT}
+      selector:
+        matchLabels: null
+      template:
+        spec:
+          bootstrap:
+            configRef:
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              kind: KubeadmConfigTemplate
+              name: ${CLUSTER_NAME}-md-0
+          clusterName: ${CLUSTER_NAME}
+          infrastructureRef:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+            kind: MicrovmMachineTemplate
+            name: ${CLUSTER_NAME}-md-0
+          version: v${KUBERNETES_VERSION}
+    
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: MicrovmMachineTemplate
+    metadata:
+      name: ${CLUSTER_NAME}-md-0
+      namespace: default
+    spec:
+      template:
+        spec:
+          kernel:
+            filename: boot/vmlinux
+            image: ghcr.io/weaveworks-liquidmetal/flintlock-kernel:5.10.77
+          kernelCmdline: {}
+          memoryMb: 2048
+          networkInterfaces:
+          - guestDeviceName: eth1
+            type: macvtap
+          rootVolume:
+            id: root
+            image: ghcr.io/weaveworks-liquidmetal/capmvm-kubernetes:${KUBERNETES_VERSION}
+            mountPoint: /
+          vcpu: 2
+    
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+    kind: KubeadmConfigTemplate
+    metadata:
+      name: ${CLUSTER_NAME}-md-0
+      namespace: default
+    spec:
+      template:
+        spec:
           joinConfiguration:
             nodeRegistration:
-              criSocket: /var/run/containerd/containerd.sock
               kubeletExtraArgs:
-                cgroup-driver: cgroupfs
-                eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-        machineTemplate:
-          infrastructureRef:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-            kind: DockerMachineTemplate
-            name: "${CLUSTER_NAME}-control-plane"
-            namespace: "${NAMESPACE}"
-        replicas: "${CONTROL_PLANE_MACHINE_COUNT}"
-        version: "${KUBERNETES_VERSION}"
-    - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: DockerMachineTemplate
-      metadata:
-        name: "${CLUSTER_NAME}-md-0"
-        namespace: "${NAMESPACE}"
-      spec:
-        template:
-          spec: {}
-    - apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-      kind: KubeadmConfigTemplate
-      metadata:
-        name: "${CLUSTER_NAME}-md-0"
-        namespace: "${NAMESPACE}"
-      spec:
-        template:
-          spec:
-            joinConfiguration:
-              nodeRegistration:
-                kubeletExtraArgs:
-                  cgroup-driver: cgroupfs
-                  eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-    - apiVersion: cluster.x-k8s.io/v1beta1
-      kind: MachineDeployment
-      metadata:
-        name: "${CLUSTER_NAME}-md-0"
-        namespace: "${NAMESPACE}"
-      spec:
-        clusterName: "${CLUSTER_NAME}"
-        replicas: "${WORKER_MACHINE_COUNT}"
-        selector:
-          matchLabels: null
-        template:
-          spec:
-            bootstrap:
-              configRef:
-                apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-                kind: KubeadmConfigTemplate
-                name: "${CLUSTER_NAME}-md-0"
-                namespace: "${NAMESPACE}"
-            clusterName: "${CLUSTER_NAME}"
-            infrastructureRef:
-              apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-              kind: DockerMachineTemplate
-              name: "${CLUSTER_NAME}-md-0"
-              namespace: "${NAMESPACE}"
-            version: "${KUBERNETES_VERSION}"
+                provider-id: microvm://{{ ds.meta_data.instance_id }}
+
+  - apiVersion: gitops.weave.works/v1alpha1
+    kind: GitopsCluster
+    metadata:
+      name: "${CLUSTER_NAME}"
+      namespace: default
+      labels:
+        weave.works/capi: bootstrap
+    spec:
+      capiClusterRef:
+        name: "${CLUSTER_NAME}"

--- a/charts/universal-crossplane-policies/Chart.yaml
+++ b/charts/universal-crossplane-policies/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: universal-crossplane-policies
+description: A Weaveworks Helm chart of Policies for the universal-crossplane Profile
+type: application
+version: 0.0.1
+kubeVersion: ">=1.16.0-0"
+home: https://github.com/weavegitops/catalog
+sources:
+  - "https://weavegitops.github.io/catalog"
+
+keywords:
+- crossplane
+- policies
+
+maintainers:
+  - name: Weaveworks
+    email: support@weave.works
+
+annotations:
+  "weave.works/profile": universal-crossplane-policies
+  "weave.works/category": Policies

--- a/charts/universal-crossplane-policies/templates/UniversalCrossplaneImageName.yaml
+++ b/charts/universal-crossplane-policies/templates/UniversalCrossplaneImageName.yaml
@@ -1,0 +1,76 @@
+apiVersion: pac.weave.works/v2beta1
+kind: Policy
+metadata:
+  name: weave.policies.universalcrossplane.image-name
+spec:
+  id: weave.policies.universalcrossplane.image_name
+  name: crossplane - Image Name
+  enabled: true
+  description: |
+    This Policy ensures an crossplane is using the correct image name. 
+  how_to_solve: |
+    If you encounter a violation, ensure the image name specified matches the official image. 
+  category: weave.categories.organizational-standards
+  severity: high
+  targets: {kinds: [Deployment, ReplicaSet, Pod]}
+  parameters:
+    - name: exclude_namespaces
+      type: array
+      required: false
+      value:
+    - name: exclude_label_key
+      type: string
+      required: false
+      value:
+    - name: exclude_label_value
+      type: string
+      required: false
+      value:
+    - name: image_name
+      type: string
+      required: true
+      value: upbound/crossplane
+  code: |
+    package weave.policies.universalcrossplane.image_name
+
+    import future.keywords.in   
+    image_name := input.parameters.image_name
+    exclude_namespaces := input.parameters.exclude_namespaces
+    exclude_label_key := input.parameters.exclude_label_key
+    exclude_label_value := input.parameters.exclude_label_value
+
+    violation[result] {
+      isExcludedNamespace == false
+      not exclude_label_value == controller_input.metadata.labels[exclude_label_key]
+      some i
+      containers := controller_spec.containers[i]
+      contains(containers.name, "crossplane")
+      not contains(containers.image, image_name)
+      result = {
+        "issue detected": true,
+        "msg": sprintf("Expected image name containing %v, found %v",[image_name, containers.image]),
+        "violating_key": sprintf("spec.template.spec.containers[%v]", [i])
+      }
+    }
+
+    array_contains(array, element) {
+      array[_].name = element
+    }
+
+    # Controller input
+    controller_input = input.review.object
+
+    # controller_container acts as an iterator to get containers from the template
+    controller_spec = controller_input.spec.template.spec {
+      contains_kind(controller_input.kind, {"Deployment","ReplicaSet","Pod"})
+    }
+
+    contains_kind(kind, kinds) {
+      kinds[_] = kind
+    }
+
+    isExcludedNamespace = true {
+    	controller_input.metadata.namespace
+    	controller_input.metadata.namespace in exclude_namespaces
+    } else = false
+


### PR DESCRIPTION
The following profiles and template have been added as an all in one demo for Universal Crossplane.

In order to use this as a demo, just use the template. There should be no additional configurations.

```
capi.weave.works/profile-2: '{"name": "universal-crossplane-policies", "version": "0.0.1"}'
```

NOTE: This is a proof of concept and do not use outside demo environments