### PR TITLE
add nfs-server profile based on nfs-subdir-external-provisioner

### DIFF
--- a/charts/nfs-server/.helmignore
+++ b/charts/nfs-server/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/nfs-server/Chart.yaml
+++ b/charts/nfs-server/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: nfs-server
+icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
+description: A Weaveworks Helm chart for nfs-server storage controller
+type: application
+version: 0.0.1
+kubeVersion: ">=1.16.0-0"
+home: https://github.com/weaveworks/profiles-catalog
+sources:
+  - https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
+keywords:
+- storage
+- nfs
+- nfs-server
+maintainers:
+  - name: Weaveworks
+    email: support@weave.works
+annotations:
+  "weave.works/profile": nfs-server
+  "weave.works/category": Storage
+  "weave.works/layer": layer-1
+  "weave.works/links": |
+    - name: Chart Sources
+      url:  https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
+    - name: Upstream Project
+      url: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/tree/master/charts/nfs-subdir-external-provisioner
+  "weave.works/profile-ci": |
+    - "gke"
+dependencies:
+- name: nfs-nfs-subdir-external-provisioner
+  version: "4.0.17"
+  repository: "https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/"

--- a/charts/nfs-server/Chart.yaml
+++ b/charts/nfs-server/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v2
 name: nfs-server
-icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 description: A Weaveworks Helm chart for nfs-server storage controller
 type: application
 version: 0.0.1

--- a/charts/nfs-server/templates/NOTES.txt
+++ b/charts/nfs-server/templates/NOTES.txt
@@ -1,0 +1,1 @@
+The nfs-server storage controller has been installed.

--- a/charts/nfs-server/templates/_helpers.tpl
+++ b/charts/nfs-server/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nfs-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nfs-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nfs-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nfs-server.labels" -}}
+helm.sh/chart: {{ include "nfs-server.chart" . }}
+{{ include "nfs-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nfs-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nfs-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nfs-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "nfs-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/nfs-server/values.yaml
+++ b/charts/nfs-server/values.yaml
@@ -1,0 +1,11 @@
+nfs-subdir-external-provisioner:
+  nfs:
+    #nfs server IP address: Demo2: 147.28.139.93 and Demo3: 147.28.139.50
+    server: 147.28.139.93
+    path: /nfs
+  storageClass:
+    onDelete: retain
+    reclaimPolicy: Retain
+    archiveOnDelete: false
+    pathPattern: "default_cluster-${.PVC.namespace}-${.PVC.name}"
+


### PR DESCRIPTION
Adding an nfs-server profile to connect to the local nfs-server on the Liquidmetal demo environments in Equinix.
This will allow us to show LM clusters with persistent storage.