### PR TITLE
Upgrade flux resources to v1in weave-policy-agent

### DIFF
--- a/charts/external-secrets/Chart.yaml
+++ b/charts/external-secrets/Chart.yaml
@@ -3,7 +3,7 @@ name: external-secrets
 icon: https://raw.githubusercontent.com/external-secrets/external-secrets/main/assets/eso-round-logo.svg
 description: A Weaveworks Helm chart for the External Secrets Operator
 type: application
-version: 0.6.1
+version: 0.7.0
 dependencies:
 - name: external-secrets
   version: "0.6.1"

--- a/charts/external-secrets/Chart.yaml
+++ b/charts/external-secrets/Chart.yaml
@@ -3,7 +3,7 @@ name: external-secrets
 icon: https://raw.githubusercontent.com/external-secrets/external-secrets/main/assets/eso-round-logo.svg
 description: A Weaveworks Helm chart for the External Secrets Operator
 type: application
-version: 0.7.0
+version: 1.0.0
 dependencies:
 - name: external-secrets
   version: "0.6.1"

--- a/charts/external-secrets/templates/secret-stores-kustomization.yaml
+++ b/charts/external-secrets/templates/secret-stores-kustomization.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.secretStores.enabled }}
 {{- if not .Values.secretStores.sourceRef }}
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: external-secrets
@@ -23,7 +23,7 @@ spec:
   {{- end }}
 {{- end }}
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: external-secrets
@@ -41,5 +41,4 @@ spec:
   {{- end }}
   path: {{ .Values.secretStores.path }}
   prune: true
-  validation: client
 {{- end }}

--- a/charts/weave-policy-agent/Chart.yaml
+++ b/charts/weave-policy-agent/Chart.yaml
@@ -20,8 +20,6 @@ maintainers:
 
 annotations:
   "weave.works/profile": weave-policy
-  "weave.works/profile-ci": |
-    - "kind"
   "weave.works/layer": layer-1
   "weave.works/category": Policy
   "weave.works/operator": "true"

--- a/charts/weave-policy-agent/Chart.yaml
+++ b/charts/weave-policy-agent/Chart.yaml
@@ -20,6 +20,8 @@ maintainers:
 
 annotations:
   "weave.works/profile": weave-policy
+  "weave.works/profile-ci": |
+    - "kind"
   "weave.works/layer": layer-1
   "weave.works/category": Policy
   "weave.works/operator": "true"

--- a/charts/weave-policy-agent/Chart.yaml
+++ b/charts/weave-policy-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Weaveworks Helm chart for Kubernetes to configure the policy agent
 name: weave-policy-agent
 appVersion: "2.4.0"
-version: 0.5.6
+version: 1.0.0
 kubeVersion: ">=1.16.0-0"
 icon: https://www.magalix.com/hubfs/Imported%20images/logo-02.png%3Fwidth=560%26name=logo-02-Dec-18-2020-11-24-41-75-AM.png
 type: application

--- a/charts/weave-policy-agent/Chart.yaml
+++ b/charts/weave-policy-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Weaveworks Helm chart for Kubernetes to configure the policy agent
 name: weave-policy-agent
-appVersion: "2.3.0"
-version: 0.5.5
+appVersion: "2.4.0"
+version: 0.5.6
 kubeVersion: ">=1.16.0-0"
 icon: https://www.magalix.com/hubfs/Imported%20images/logo-02.png%3Fwidth=560%26name=logo-02-Dec-18-2020-11-24-41-75-AM.png
 type: application
@@ -29,5 +29,5 @@ annotations:
 
 dependencies:
   - name: policy-agent
-    version: "2.3.0"
+    version: "2.4.0"
     repository: "https://weaveworks.github.io/policy-agent"

--- a/charts/weave-policy-agent/requirements.lock
+++ b/charts/weave-policy-agent/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: policy-agent
   repository: https://weaveworks.github.io/policy-agent
-  version: 2.3.0
-digest: sha256:cd5b8802d4cd48cc47c6436a3248f912cabc9a79bf777c19400199000da16380
-generated: "2023-02-19T16:45:23.028925429+02:00"
+  version: 2.4.0
+digest: sha256:63bbeef8a270e044ed55e6a4655cfffbfa926f7ceb1875f8e4a0fec5a37930ab
+generated: "2023-05-31T13:44:29.700455687+03:00"

--- a/charts/weave-policy-agent/templates/policy-library.yaml
+++ b/charts/weave-policy-agent/templates/policy-library.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.policySource.enabled }}
 {{- if not .Values.policySource.sourceRef }}
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: policy-library
@@ -23,7 +23,7 @@ spec:
   {{- end }}
 {{- end }}
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: policy-library
@@ -41,5 +41,4 @@ spec:
   {{- end }}
   path: {{ .Values.policySource.path }}
   prune: true
-  validation: client
 {{- end }}


### PR DESCRIPTION
This PR upgrades charts that create Kustomization and GitRepository `v1beta2` CRs to `v1` CRs and bumps the agent profile to policy-agent 2.4.0.